### PR TITLE
Set correct DRM event context version

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -34,6 +34,8 @@ use std::os::unix::io;
 
 use ffi;
 
+pub const DRM_CONTEXT_VERSION: libc::c_int = 2; /**< Desired DRM event context version */
+
 /// Trait for contexts passed to `handle_event`.
 pub trait EventContext {
     fn vblank_handler(&mut self, fd: io::RawFd, sequence: u32, sec: u32, usec: u32, data: i32);
@@ -72,7 +74,7 @@ pub fn handle_event(fd: io::RawFd, context: Box<EventContext>) {
     CONTEXT.with(|s| *s.borrow_mut() = Some(context));
 
     let mut drm_context = ffi::xf86drm::drmEventContext::default();
-    drm_context.version = ffi::xf86drm::DRM_EVENT_CONTEXT_VERSION;
+    drm_context.version = DRM_CONTEXT_VERSION;
     drm_context.vblank_handler = vblank_handler;
     drm_context.page_flip_handler = page_flip_handler;
     unsafe {


### PR DESCRIPTION
DRM_EVENT_CONTEXT_VERSION is the latest context version supported by
whatever version of libdrm is present. igt was blindly asserting it
supported whatever version that may be, even if it actually didn't.

With libdrm 2.4.78, setting a higher context version than 2 will attempt
to call the page_flip_handler2 vfunc if it was non-NULL, which being a
random chunk of stack memory, it might well have been.

Set the version as 2, which should be bumped only with the appropriate
version checks.

Signed-off-by: Daniel Stone <daniels@collabora.com>